### PR TITLE
J-all-304 feat: add Divider button to Quill toolbar

### DIFF
--- a/src/components/TextEditors/QuillEditor2.js
+++ b/src/components/TextEditors/QuillEditor2.js
@@ -48,6 +48,10 @@ Quill.register('modules/mention', QuillMention);
 Quill.register(CustomCodeBlock, true);
 Quill.register(MyLink);
 Quill.register(DividerBlot);
+// Custom toolbar formats render a blank button unless given an icon, so supply
+// one for the divider control here (once, at module load).
+const quillIcons = Quill.import('ui/icons');
+quillIcons['divider'] = '<svg viewBox="0 0 18 18"><line class="ql-stroke" x1="3" y1="9" x2="15" y2="9"></line></svg>';
 const useStyles = makeStyles(
   theme => {
     return {

--- a/src/components/TextEditors/Utilities/CoreUtils.js
+++ b/src/components/TextEditors/Utilities/CoreUtils.js
@@ -118,6 +118,7 @@ function addToolTips (toolbar) {
   setTooltip(toolbar, 'button.ql-strike', 'Strike');
   setTooltip(toolbar, 'button.ql-list', 'Number List', 'Bullet List');
   setTooltip(toolbar, 'button.ql-table', 'Table');
+  setTooltip(toolbar, 'button.ql-divider', 'Divider');
   setTooltip(toolbar, 'span.ql-color', 'Text Color');
   setTooltip(toolbar, 'span.ql-background', 'Background Color');
   setTooltip(toolbar, 'span.ql-align', 'Text Alignment');
@@ -377,6 +378,12 @@ export function generateEditorOptions (id, config) {
             const {editor} = QuillEditorRegistry.getEditor(id);
             editor.format('link', false);
           }
+        },
+        'divider': () => {
+          const {editor} = QuillEditorRegistry.getEditor(id);
+          const range = editor.getSelection(true);
+          editor.insertEmbed(range.index, 'divider', true, 'user');
+          editor.setSelection(range.index + 1, 0, 'silent');
         }
       },
       //for various reasons, the array form is stored in the container property when you're
@@ -388,7 +395,7 @@ export function generateEditorOptions (id, config) {
         [{ color: [] }, { background: [] }],
         [{ align: [] }],
         [{ list: 'ordered' }, { list: 'bullet' }, { indent: '-1' }, { indent: '+1' }],
-        ['link', 'code-block', 'image', 'video'],
+        ['link', 'code-block', 'image', 'video', 'divider'],
         ['table'],
         ['clean'],
       ]
@@ -438,7 +445,7 @@ export function generateEditorOptions (id, config) {
       [{ color: [] }, { background: [] }],
       [{ align: [] }],
       [{ list: 'ordered' }, { list: 'bullet' }, { indent: '-1' }, { indent: '+1' }],
-      ['link', 'code-block'],
+      ['link', 'code-block', 'divider'],
       ['table'],
       ['clean'],
     ];


### PR DESCRIPTION
## Summary
Exposes the existing `divider` blot as a toolbar button so users can insert a horizontal rule directly, rather than relying only on the backend markdown→Quill `<hr>` path.

Added to the **full** and **uploadDisabled** toolbars, intentionally **not** the minimal `simple` reply bar (per J-all-304 / Q-all-86).

## Changes
- **`CoreUtils.js`** — `'divider'` added to the full and `uploadDisabled` toolbar containers; a `divider` insert handler mirroring the existing link/video pattern (`insertEmbed(range.index, 'divider', true, 'user')` + cursor reposition); a "Divider" tooltip.
- **`QuillEditor2.js`** — registers the toolbar button icon at module load (custom formats render a blank button without one).

Reuses the existing `DividerBlot`; no new dependencies. eslint passes. Verified in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)