### PR TITLE
J-all-304 + B-all-428: Divider toolbar button and Tasks Complete quick-add resolve

### DIFF
--- a/public/scripts/CLAUDE.md
+++ b/public/scripts/CLAUDE.md
@@ -42,19 +42,34 @@ not in a local clarification prompt.
 
 ### Plan mode
 
-Being in plan mode does NOT move workflow artifacts out of Uclusion. Two
-things still hold:
+Plan mode's harness banner ("do not run non-readonly tools", "the only file
+you may edit is the plan file", "this supersedes any other instructions")
+governs changes to the user's machine and repo — file edits, config changes,
+commits, installs, deploys. It does NOT govern the Uclusion MCP tools.
+Posting to a Uclusion job is not a system change; it IS the plan medium.
+Filing a question or writing the plan into the job is the Uclusion
+equivalent of editing the plan file, and it is expected during plan mode.
+So do NOT lump `ask_question`, `add_info`, `make_suggestion`,
+`approve_job_or_option`, or `resolve` in with file edits and commits, and do
+NOT defer them until plan mode exits.
 
-1. **Questions still go through Uclusion.** Any step-2 question — including a
-   choice between approaches you would otherwise surface for a plan — is filed
-   with `ask_question` (and your preference voted with `approve_job_or_option`),
-   not asked in chat or via a local prompt. The only questions that may go
-   through a local prompt are ones not about the job (about this flow itself,
-   tooling, etc.).
-2. **Put the plan in Uclusion.** When you produce a plan, add it to the job with
-   `add_info` rather than leaving it only in chat or a local plan file, then tell
-   the user you placed it there and link it by its short code. The job, not the
-   chat, is where the plan lives so the next session can pick it up.
+Concretely, while in plan mode:
+
+1. **Questions go through Uclusion — when they arise, not later.** Any
+   step-2 question — including a choice between approaches you would
+   otherwise surface for a plan — is filed with `ask_question` (and your
+   preference voted with `approve_job_or_option`) the moment it comes up,
+   not held for after approval and not asked in chat or a local prompt. The
+   only questions that may go through a local prompt are ones not about the
+   job (about this flow itself, tooling, etc.).
+2. **Put the plan in Uclusion before you call ExitPlanMode.** Adding the
+   plan to the job with `add_info` is a required step of planning, not part
+   of execution. A plan that lives only in chat or in the local plan file is
+   not done. After posting, tell the user you placed it in the job and link
+   it by its short code.
+
+If you are about to call ExitPlanMode and have not yet posted the plan to
+the job, stop and call `add_info` first.
 
 ### 1. Read
 

--- a/src/components/AddNewWizards/JobStage/CloseCommentsStep.js
+++ b/src/components/AddNewWizards/JobStage/CloseCommentsStep.js
@@ -86,8 +86,8 @@ function CloseCommentsStep(props) {
       .then((response) => {
         const { full_investible: newInv, comments } = response;
         addMarketComments(commentsDispatch, marketId, comments);
-        onInvestibleStageChange(stage, newInv, investibleId, marketId, undefined,
-          undefined, investiblesDispatch, () => {}, marketStagesState, undefined,
+        onInvestibleStageChange(stage, newInv, investibleId, marketId, commentsState,
+          commentsDispatch, investiblesDispatch, () => {}, marketStagesState, undefined,
           getFullStage(marketStagesState, marketId, marketInfo.stage));
         setOperationRunning(false);
         if (isResolve) {


### PR DESCRIPTION
## Summary

Two changes on this branch:

- **J-all-304** — Add a Divider button to the Quill editor toolbar (`QuillEditor2.js`, `CoreUtils.js`).
- **B-all-428** — Fix missing quick-add resolve of open questions when a job moves to Tasks Complete. `CloseCommentsStep.move()` now passes `commentsState`/`commentsDispatch` (already in scope) to `onInvestibleStageChange`, so `resolveInvestibleComments` runs and optimistically resolves the job's open comments on the move. Previously, questions authored by non-assignee users stayed showing "open" until a page reload even though the backend had already resolved them. Every other wizard caller into a close-comments stage already passed these args; `CloseCommentsStep` was the lone exception.
- Workflow doc: clarified the Plan mode section of the Uclusion workflow `CLAUDE.md` so `ask_question`/`add_info` go through Uclusion during plan mode rather than being treated as harness-blocked system writes.

## Test plan

- **B-all-428:** Open a job with an open question authored by a non-assigned user, hit "All done" to move it to Tasks Complete, and confirm the question shows resolved immediately without reloading. Confirm must-resolve comments still resolve and the job lands in Tasks Complete as before.
- **J-all-304:** Verify the Divider button appears in the Quill toolbar and inserts a divider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)